### PR TITLE
Update information on fees

### DIFF
--- a/content/pages/admissions.md
+++ b/content/pages/admissions.md
@@ -25,8 +25,8 @@ once a place is confirmed.
 
 ## Fees
 
-Our current session fees are &pound;17.50 per 3 hour session for children not
-eligible for funding.
+From September 2024 our session fees are &pound;18.50 per 3 hour session for
+children not eligible for funding.
 
 Under the Early Years Free Entitlement system, all three and four year
 olds are entitled to 15 hours per week from the term following their 3rd
@@ -34,7 +34,17 @@ birthday, for up to 38 weeks per year. Once your child becomes eligible
 for funding, we do expect you to use your full 15 hours with us. We do not
 currently accept extended hours funding. 
 
-In addition, we request a contribution of 25p per session towards the
+From April 2024 there are some changes to funded childcare for eligible working
+families of 2 year olds.  Follow the link below to the Oxfordshire County
+Council guidance on the eligibility criteria and how to apply.  If you are
+entitled to this funding, please [contact us](/contact) so that we can confirm
+your eligibility.  Please note, if you think you may be eligible, your child
+must have turned 2 before the 31st March 2024 to be entitled to funding for the
+Summer Term.
+
+* [Free early education for 2 year olds - Oxfordshire County Council](https://www.oxfordshire.gov.uk/residents/children-education-and-families/early-years-education/free-education-2-year-olds)
+
+Additionally, we request a contribution of 35p per morning session towards the
 snacks we provide. 
 
 All fees are invoiced termly, in advance.


### PR DESCRIPTION
* Fees increasing to £18.50
* 2 year old funding guidance link
* Snack fees increasing to 35p, but only for morning sessions